### PR TITLE
Adds Looker PR template

### DIFF
--- a/pr_templates/looker_modeling_pr.md
+++ b/pr_templates/looker_modeling_pr.md
@@ -1,0 +1,25 @@
+## Overview
+_Summarize the goal of your work and what motivated it._
+
+## Key changes
+- _Describe major updates._
+
+## Other notes
+- _List open questions and other things your reviewer should know._
+
+## Related links
+- _List links to related ticket(s)._
+- _(optional) Link to other files and resources, such as specific related reports in Looker or PRs in the dbt repo._
+
+## QA
+- _Describe how you evaluated the accuracy of the results (e.g. "picked these 10 IDs from source system and compared aggregated values and compared overall summary to July report")_
+- _List links to QA-related items, e.g. to a SQL file used to compare outputs to some benchmark and a file that is reporting on the same topic._
+
+## Checklist
+- [ ] Communicating with users:
+    - [ ] All added / modified files create new features (e.g., Looks, Explores, Dashboards, fields, elements) that will not impact existing stakeholder workflow(s).
+    - [ ] This PR may / will impact existing stakeholder workflow(s) and there is a stakeholder communication plan in place. 
+- [ ] LookML model(s) connection(s) reverted to production.
+
+## Screenshots
+_Include screenshots that demonstrate the new feature(s)._


### PR DESCRIPTION
## Overview
Publishing a copy of our Looker PR template. It's used to standardize how we communicate LookML development work that gets reviewed in in GitHub PRs. The template also includes reminders to the developer to share QA work, screenshots, and links to relevant content (i.e. user story). 